### PR TITLE
Add clear function to BinaryStream

### DIFF
--- a/source/MP4.BinaryStream.cpp
+++ b/source/MP4.BinaryStream.cpp
@@ -605,3 +605,8 @@ std::istream & BinaryStream::seekg( std::streamoff off, std::ios_base::seekdir d
 {
     return stream.seekg( off, dir );
 }
+
+void BinaryStream::clear( void )
+{
+    return stream.clear();
+}

--- a/source/include/MP4.BinaryStream.h
+++ b/source/include/MP4.BinaryStream.h
@@ -129,6 +129,7 @@ namespace MP4
             std::istream & unget( void );
             std::istream & seekg( std::streampos pos );
             std::istream & seekg( std::streamoff off, std::ios_base::seekdir dir );
+            void clear( void );
     };
 }
 


### PR DESCRIPTION
-Simply allow istream clear function to be called from Binary Stream
-This is necessary for putting the stream back into a good (reusable)
state after eof has been hit
